### PR TITLE
Fix lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,7 @@ jobs:
 
       - name: Run Molecule
         run: molecule test
+        env:
+          ANSIBLE_ROLES_PATH: ".."
+        env:
+          ANSIBLE_ROLES_PATH: ".."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches: [master]
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   ANSIBLE_DEPRECATION_WARNINGS: "false"
 
 jobs:
@@ -32,6 +32,8 @@ jobs:
 
       - name: Run ansible-lint
         run: ansible-lint
+        env:
+          ANSIBLE_ROLES_PATH: ".."
 
   molecule:
     name: Molecule

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ driver:
 
 platforms:
   - name: debian12
-    image: geerlingguy/docker-debian12-ansible@sha256:3232ce7d506146b149802b561f49871dde8339fa6cb0e175c69db69530cedd47 # yamllint disable-line rule:line-length
+    image: geerlingguy/docker-debian12-ansible@sha256:3232ce7d506146b149802b561f49871dde8339fa6cb0e175c69db69530cedd47  # yamllint disable-line rule:line-length
     command: /lib/systemd/systemd
     tmpfs:
       - /run

--- a/tests/debian12.yaml
+++ b/tests/debian12.yaml
@@ -1,3 +1,4 @@
+---
 # Lima VM definition for Ansible testing
 # Usage: limactl start --name=hostname-ascii-test tests/debian12.yaml
 


### PR DESCRIPTION
- molecule.yml: add second space before inline comment (yaml[comments])
- ci.yml: quote FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 value (truthy)
- ci.yml: set ANSIBLE_ROLES_PATH=.. for ansible-lint so it can resolve the role during syntax-check
- tests/debian12.yaml: add missing document start ---